### PR TITLE
README still has v2 in the example code which WILL delete labels by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1.0.0
-      - uses: lannonbr/issue-label-manager-action@2.0.0
+      - uses: lannonbr/issue-label-manager-action@3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The comment in the readme suggests that `delete` defaults to false, but the version 2.0.0 in the `uses:` string still defaults to true.
So copying this example and removing the `delete` option WILL result in potential deletion of labels.